### PR TITLE
implement configurable nullable type, resolves #4

### DIFF
--- a/Documentation/BuiltInFunctions.md
+++ b/Documentation/BuiltInFunctions.md
@@ -201,7 +201,7 @@ Returns the url for the Web API action based on route attributes (or the supplie
 #### ToTypeScript
 
 ```csharp
-IEnumerable<string> Parameters.ToTypeScript(IEnumerable<IParameter> parameters)
+IEnumerable<string> Parameters.ToTypeScript(IEnumerable<IParameter> parameters, string nullableType = "null")
 ```
 
 
@@ -325,7 +325,7 @@ The default value of the type.            (Dictionary types returns {}, enumerab
 #### ToTypeScriptType
 
 ```csharp
-string Type.ToTypeScriptType(IType type)
+string Type.ToTypeScriptType(IType type, string nullableType = "null")
 ```
 Converts type name to typescript type name
 

--- a/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
@@ -26,8 +26,8 @@ namespace NTypewriter.CodeModel.Functions.Tests.Type
                                      for class in data.Classes | Symbols.WhereNameStartsWith ""AllReferencedTypes""
                                          for type in class | Type.AllReferencedTypes
                                              type.Name | String.Append ""\r\n""
-                                         end 
-                                      end 
+                                         end
+                                      end
                                   end
                                   Save output ""Some name"" }}
                             ";
@@ -48,19 +48,19 @@ BaseType
         }
 
 
-            [TestMethod]
+        [TestMethod]
         public async Task ToTypeScriptType_Simple()
         {
             var template = @"{{- capture output
                                      for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
-                                         for field in class.Fields 
+                                         for field in class.Fields
                                              field.Type | Type.ToTypeScriptType | String.Append ""\r\n""
-                                         end 
-                                      end 
+                                         end
+                                      end
                                   end
                                   Save output ""Some name"" }}
                             ";
-            var result = await NTypeWriter.Render(template, data, null);          
+            var result = await NTypeWriter.Render(template, data, null);
             var actual = result.Items.First().Content;
             var expected = @"
 boolean
@@ -81,10 +81,10 @@ any";
         {
             var template = @"{{- capture output
                                      for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Complex""
-                                         for field in class.Fields 
+                                         for field in class.Fields
                                              field.Type | Type.ToTypeScriptType | String.Append ""\r\n""
-                                         end 
-                                      end 
+                                         end
+                                      end
                                   end
                                   Save output ""Some name"" }}
                             ";
@@ -96,24 +96,139 @@ MyGeneric<number>
 number[]
 number[]
 MyGeneric<number | null>
-number | null[]
-number | null[]
+(number | null)[]
+(number | null)[]
 MyGeneric<number | null> | null
-number | null[] | null
-number | null[] | null
+(number | null)[] | null
+(number | null)[] | null
 { [key: string]: number }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Simple_CustomNullableType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType ""undefined"" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+boolean
+number
+number | undefined
+string
+string | undefined
+MyEnum
+MyEnum | undefined
+Promise<number>
+number
+any";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Complex_CustomNullableType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Complex""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType ""undefined"" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+number[]
+MyGeneric<number>
+number[]
+number[]
+MyGeneric<number | undefined>
+(number | undefined)[]
+(number | undefined)[]
+MyGeneric<number | undefined> | undefined
+(number | undefined)[] | undefined
+(number | undefined)[] | undefined
+{ [key: string]: number }";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Simple_EmptyNullableType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType """" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+boolean
+number
+number
+string
+string
+MyEnum
+MyEnum
+Promise<number>
+number
+any";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Complex_EmptyNullableType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Complex""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType """" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+number[]
+MyGeneric<number>
+number[]
+number[]
+MyGeneric<number>
+number[]
+number[]
+MyGeneric<number>
+number[]
+number[]
+{ [key: string]: number }";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
 
         [TestMethod]
         public async Task ToTypeScriptDefault()
         {
             var template = @"{{- capture output
                                      for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptDefault""
-                                         for field in class.Fields 
+                                         for field in class.Fields
                                              field.Type | Type.ToTypeScriptDefault | String.Append ""\r\n""
-                                         end 
-                                      end 
+                                         end
+                                      end
                                   end
                                   Save output ""Some name"" }}
                             ";

--- a/NTypewriter.CodeModel.Functions/ParametersFunctions.cs
+++ b/NTypewriter.CodeModel.Functions/ParametersFunctions.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 
 namespace NTypewriter.CodeModel.Functions
 {
@@ -11,11 +9,11 @@ namespace NTypewriter.CodeModel.Functions
     public static class ParametersFunctions
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public static IEnumerable<string> ToTypeScript(this IEnumerable<IParameter> parameters)
+        public static IEnumerable<string> ToTypeScript(this IEnumerable<IParameter> parameters, string nullableType = "null")
         {
-            return parameters.Select(x => $"{x.BareName}: {x.Type.ToTypeScriptType()}");
+            return parameters.Select(x => $"{x.BareName}: {x.Type.ToTypeScriptType(nullableType)}");
         }
     }
 }


### PR DESCRIPTION
This PR resolves #4, it enables developers to customize the nullable postfix. Currently, the default is "null", but examples of postfixes that others might want to use are "undefined", "null | undefined", or even no postfix at all ("").

This PR also fixes arrays that have a nullable element type. It turns int | null[] into (int | null)[], and it also works with custom nullable postfixes of course. I could've used Array<...> instead, but I decided that because (...)[] is shorter, it's probably the preferred way to go.