### PR TITLE
Types.ToTypescriptType should return string for TimeSpan type members

### DIFF
--- a/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Simple/inputCode.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Simple/inputCode.cs
@@ -26,6 +26,8 @@ namespace NTypewriter.CodeModel.Functions.Tests.Type.ToTypeScriptType_Simple
         [Required]
         int? nullableInteger2;
         dynamic dynamic;
+        TimeSpan timeSpan;
+        TimeSpan? optionalTimeSpan;
 
 
 

--- a/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
@@ -73,7 +73,9 @@ MyEnum
 MyEnum | null
 Promise<number>
 number
-any";
+any
+string
+string | null";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -130,7 +132,9 @@ MyEnum
 MyEnum | undefined
 Promise<number>
 number
-any";
+any
+string
+string | undefined";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -187,7 +191,9 @@ MyEnum
 MyEnum
 Promise<number>
 number
-any";
+any
+string
+string";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 

--- a/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
+++ b/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
@@ -104,6 +104,8 @@ namespace NTypewriter.CodeModel.Functions
                 case "System.DateTime":
                 case "System.DateTimeOffset":
                     return "Date";
+                case "System.TimeSpan":
+                    return "string";
                 case "System.Void":
                     return "void";
                 case "System.Object":


### PR DESCRIPTION
This fixes #12

.Net returns System.TimeSpan types as strings through the API. So when ToTypescriptType encounters a TimeSpan member, it should return string as the base type.