### PR TITLE
Add optional type to Type.ToTypeScriptType for DateTime and DateTimeOffset

### DIFF
--- a/Documentation/BuiltInFunctions.md
+++ b/Documentation/BuiltInFunctions.md
@@ -201,7 +201,7 @@ Returns the url for the Web API action based on route attributes (or the supplie
 #### ToTypeScript
 
 ```csharp
-IEnumerable<string> Parameters.ToTypeScript(IEnumerable<IParameter> parameters, string nullableType = "null")
+IEnumerable<string> Parameters.ToTypeScript(IEnumerable<IParameter> parameters, string nullableType = "null", string customDateType = "Date")
 ```
 
 
@@ -325,9 +325,38 @@ The default value of the type.            (Dictionary types returns {}, enumerab
 #### ToTypeScriptType
 
 ```csharp
-string Type.ToTypeScriptType(IType type, string nullableTypePostfix = "null")
+string Type.ToTypeScriptType(IType type, string nullableTypePostfix = "null", string customDateType = "Date")
 ```
-Converts type name to typescript type name
+Converts type name to typescript type name.
+If you specify the argument after the type, you can specify the type that will be used for optional types. For instance, if your C# code looks like:
+
+```csharp
+public int? prop
+```
+
+by default this will turn into
+
+```JS
+number | null
+```
+
+but you can specify a different type like "undefined" using:
+
+```JS
+type | Type.ToTypeScriptType "undefined"
+```
+
+Or you can remove the optionality completely by specifying an empty string for the nullable type like this:
+
+```JS
+type | Type.ToTypeScriptType ""
+```
+
+For DateTime and DateTimeOffset types in your C# code, the default type used is JS's Date object. Sometimes it is much easier to deal with these data types as strings since that is typically what is passed back and forth between the front end and the back end. You can change the behaviour by specifying a parameter after the nullable type parameter. like this:
+
+```JS
+type | Type.ToTypeScriptType "null" "string"
+```
 
 #### Unwrap
 

--- a/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Simple/inputCode.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Simple/inputCode.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NTypewriter.CodeModel.Functions.Tests.Type.ToTypeScriptType_Simple
@@ -28,7 +25,10 @@ namespace NTypewriter.CodeModel.Functions.Tests.Type.ToTypeScriptType_Simple
         dynamic dynamic;
         TimeSpan timeSpan;
         TimeSpan? optionalTimeSpan;
-
+        DateTime date;
+        DateTime? optionalDate;
+        DateTimeOffset dateOffset;
+        DateTimeOffset? optionalDateOffset;
 
 
 

--- a/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
@@ -75,7 +75,11 @@ Promise<number>
 number
 any
 string
-string | null";
+string | null
+Date
+Date | null
+Date
+Date | null";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -134,7 +138,11 @@ Promise<number>
 number
 any
 string
-string | undefined";
+string | undefined
+Date
+Date | undefined
+Date
+Date | undefined";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -193,7 +201,11 @@ Promise<number>
 number
 any
 string
-string";
+string
+Date
+Date
+Date
+Date";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -226,6 +238,107 @@ number[]
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
+        [TestMethod]
+        public async Task ToTypeScriptType_Simple_CustomDateType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType ""null"" ""custom"" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+boolean
+number
+number | null
+string
+string | null
+MyEnum
+MyEnum | null
+Promise<number>
+number
+any
+string
+string | null
+custom
+custom | null
+custom
+custom | null";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Simple_EmptyDateType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType ""null"" """" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+boolean
+number
+number | null
+string
+string | null
+MyEnum
+MyEnum | null
+Promise<number>
+number
+any
+string
+string | null
+Date
+Date | null
+Date
+Date | null";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
+
+        [TestMethod]
+        public async Task ToTypeScriptType_Simple_CustomNullableType_CustomDateType()
+        {
+            var template = @"{{- capture output
+                                     for class in data.Classes | Symbols.WhereNameStartsWith ""ToTypeScriptType_Simple""
+                                         for field in class.Fields
+                                             field.Type | Type.ToTypeScriptType ""undefined"" ""custom"" | String.Append ""\r\n""
+                                         end
+                                      end
+                                  end
+                                  Save output ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, null);
+            var actual = result.Items.First().Content;
+            var expected = @"
+boolean
+number
+number | undefined
+string
+string | undefined
+MyEnum
+MyEnum | undefined
+Promise<number>
+number
+any
+string
+string | undefined
+custom
+custom | undefined
+custom
+custom | undefined";
+            Assert.AreEqual(expected.Trim(), actual.Trim());
+        }
 
         [TestMethod]
         public async Task ToTypeScriptDefault()

--- a/NTypewriter.CodeModel.Functions/ParametersFunctions.cs
+++ b/NTypewriter.CodeModel.Functions/ParametersFunctions.cs
@@ -11,9 +11,9 @@ namespace NTypewriter.CodeModel.Functions
         /// <summary>
         ///
         /// </summary>
-        public static IEnumerable<string> ToTypeScript(this IEnumerable<IParameter> parameters, string nullableType = "null")
+        public static IEnumerable<string> ToTypeScript(this IEnumerable<IParameter> parameters, string nullableType = "null", string customDateType = "")
         {
-            return parameters.Select(x => $"{x.BareName}: {x.Type.ToTypeScriptType(nullableType)}");
+            return parameters.Select(x => $"{x.BareName}: {x.Type.ToTypeScriptType(nullableType, customDateType)}");
         }
     }
 }

--- a/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
+++ b/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
@@ -11,7 +11,7 @@ namespace NTypewriter.CodeModel.Functions
         /// <summary>
         /// Converts type name to typescript type name
         /// </summary>
-        public static string ToTypeScriptType(this IType type, string nullableTypePostfix = "null")
+        public static string ToTypeScriptType(this IType type, string nullableTypePostfix = "null", string customDateType = "")
         {
             if (type == null)
             {
@@ -25,10 +25,14 @@ namespace NTypewriter.CodeModel.Functions
                     postfix = " | " + (nullableTypePostfix ?? "null");
                 }
             }
-            return ToTypeScriptTypePhase2(type, nullableTypePostfix) + postfix;
+            if (string.IsNullOrWhiteSpace(customDateType))
+            {
+                customDateType = "Date";
+            }
+            return ToTypeScriptTypePhase2(type, nullableTypePostfix, customDateType) + postfix;
         }
 
-        private static string ToTypeScriptTypePhase2(IType type, string nullableTypePostfix)
+        private static string ToTypeScriptTypePhase2(IType type, string nullableTypePostfix, string dateType)
         {
             if (type.IsArray)
             {
@@ -43,7 +47,7 @@ namespace NTypewriter.CodeModel.Functions
             }
             if (type.IsGeneric)
             {
-                var arguments = type.TypeArguments.Select(x => ToTypeScriptType(x, nullableTypePostfix)).ToList();
+                var arguments = type.TypeArguments.Select(x => ToTypeScriptType(x, nullableTypePostfix, dateType)).ToList();
 
                 if (type.IsNullable && type.IsValueType)
                 {
@@ -74,13 +78,13 @@ namespace NTypewriter.CodeModel.Functions
                 }
 
                 // common generic : MyGeneric<int,string>
-                var name = TranslateNameToTypeScriptName(type);
+                var name = TranslateNameToTypeScriptName(type, dateType);
                 return $"{name}<{ String.Join(",", arguments) }>";
             }
 
-            return TranslateNameToTypeScriptName(type);
+            return TranslateNameToTypeScriptName(type, dateType);
         }
-        private static string TranslateNameToTypeScriptName(IType type)
+        private static string TranslateNameToTypeScriptName(IType type, string dateType)
         {
             switch (type.FullName)
             {
@@ -103,7 +107,7 @@ namespace NTypewriter.CodeModel.Functions
                     return "number";
                 case "System.DateTime":
                 case "System.DateTimeOffset":
-                    return "Date";
+                    return dateType;
                 case "System.TimeSpan":
                     return "string";
                 case "System.Void":


### PR DESCRIPTION
This fixes issue #13 

As pointed out in the issue, .Net Web API actually sends DateTime and DateTimeOffset back and forth between the front end and the back end as strings. This means that the best practice should be to define these values as strings.

However, Typewriter originally defined these as the JS Date object. So keeping with Typewriter's lead, we are keeping the Date object as the default, but allowing the user to specify a different value for these date types.

This commit adds another argument to ToTypeScriptType that allows the user to specify the Date type.

The unit tests have been updated as well as the documentation.  And this also affects the Parameter.ToTypeScript function as well. It also gets a new argument. (note: at this point in time there are no unit tests for Parameter.ToTypeScript)