### PR TITLE
added withoutBodyParameter argument to Parameters

### DIFF
--- a/Documentation/BuiltInFunctions.md
+++ b/Documentation/BuiltInFunctions.md
@@ -176,9 +176,9 @@ Returns the http method used with a webapi action.            The http method is
 #### Parameters
 
 ```csharp
-IEnumerable<IParameter> Action.Parameters(IMethod method)
+IEnumerable<IParameter> Action.Parameters(IMethod method, bool withoutBodyParameter = false)
 ```
-Returns parameters that receive content sent to a webapi action.
+Returns parameters that receive content sent to a webapi action.            If _withoutBodyParameter_ is specified as true, then the Parameter list returned will not include the parameter that is being sent in the body of the request.
 
 #### ReturnType
 

--- a/NTypewriter.CodeModel.Functions.Tests/Action/ActionFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Action/ActionFunctionsTests.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NTypewriter.CodeModel.Roslyn;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace NTypewriter.CodeModel.Functions.Tests.Method
 {
@@ -38,7 +35,7 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
             var result = await NTypeWriter.Render(template, data, settings);
             var actual = RemoveWhitespace(result.Items.First().Content);
 
-            var expected = "[GetData:get][SomeAsync:put][SomeAsync2:delete]";
+            var expected = "[GetData:get][GetDataNoBody:get][SomeAsync:put][SomeAsync2:delete]";
             Assert.AreEqual(expected, actual);
         }
 
@@ -58,7 +55,65 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
             var result = await NTypeWriter.Render(template, data, settings);
             var actual = RemoveWhitespace(result.Items.First().Content);
 
-            var expected = "[GetData:intbody][SomeAsync:InputDTObody][SomeAsync2:InputDTObody]";
+            var expected = "[GetData:intbody][GetDataNoBody:][SomeAsync:InputDTObody][SomeAsync2:InputDTObody]";
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [TestMethod]
+        public async Task Parameters()
+        {
+            var template = @"{{- capture result }}
+                                {{- for class in data.Classes | Types.ThatInheritFrom ""ControllerBase"" }}
+                                   {{- for method in class.Methods }}                            
+                                      [{{- method.Name }} : {{- method | Action.Parameters }}]
+                                   {{- end }}
+                                {{- end }}
+                             {{- end }}
+                             {{- Save result ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, settings);
+            var actual = RemoveWhitespace(result.Items.First().Content);
+
+            var expected = "[GetData:[intbody]][GetDataNoBody:[inturl]][SomeAsync:[InputDTObody,Pagginationpagg]][SomeAsync2:[intpar3,InputDTObody,doublepar1,boolpar2,intpar4,intpar5]]";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public async Task Parameters_without_body_parameters_true()
+        {
+            var template = @"{{- capture result }}
+                                {{- for class in data.Classes | Types.ThatInheritFrom ""ControllerBase"" }}
+                                   {{- for method in class.Methods }}                            
+                                      [{{- method.Name }} : {{- method | Action.Parameters true }}]
+                                   {{- end }}
+                                {{- end }}
+                             {{- end }}
+                             {{- Save result ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, settings);
+            var actual = RemoveWhitespace(result.Items.First().Content);
+
+            var expected = "[GetData:[]][GetDataNoBody:[inturl]][SomeAsync:[Pagginationpagg]][SomeAsync2:[intpar3,doublepar1,boolpar2,intpar4,intpar5]]";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public async Task Parameters_without_body_parameters_false()
+        {
+            var template = @"{{- capture result }}
+                                {{- for class in data.Classes | Types.ThatInheritFrom ""ControllerBase"" }}
+                                   {{- for method in class.Methods }}                            
+                                      [{{- method.Name }} : {{- method | Action.Parameters false }}]
+                                   {{- end }}
+                                {{- end }}
+                             {{- end }}
+                             {{- Save result ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, settings);
+            var actual = RemoveWhitespace(result.Items.First().Content);
+
+            var expected = "[GetData:[intbody]][GetDataNoBody:[inturl]][SomeAsync:[InputDTObody,Pagginationpagg]][SomeAsync2:[intpar3,InputDTObody,doublepar1,boolpar2,intpar4,intpar5]]";
             Assert.AreEqual(expected, actual);
         }
 
@@ -78,7 +133,7 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
             var result = await NTypeWriter.Render(template, data, settings);
             var actual = RemoveWhitespace(result.Items.First().Content);
 
-            var expected = "[GetData:WeatherForecast/hkk][SomeAsync:sd?page=${pagg.page}&limit=${pagg.limit}][SomeAsync2:WeatherForecast/akacja/${par1}/${par2}/${par3}?par4=${par4}&par5=${par5}]";
+            var expected = "[GetData:WeatherForecast/hkk][GetDataNoBody:WeatherForecast/hkk/${url}][SomeAsync:sd?page=${pagg.page}&limit=${pagg.limit}][SomeAsync2:WeatherForecast/akacja/${par1}/${par2}/${par3}?par4=${par4}&par5=${par5}]";
                           
             Assert.AreEqual(expected, actual);
         }

--- a/NTypewriter.CodeModel.Functions/ActionFunctions.Parameters.cs
+++ b/NTypewriter.CodeModel.Functions/ActionFunctions.Parameters.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace NTypewriter.CodeModel.Functions
 {
@@ -9,8 +7,9 @@ namespace NTypewriter.CodeModel.Functions
     {
         /// <summary>
         /// Returns parameters that receive content sent to a webapi action.
+        /// If _withoutBodyParameter_ is specified as true, then the Parameter list returned will not include the parameter that is being sent in the body of the request.
         /// </summary>
-        public static IEnumerable<IParameter> Parameters(this IMethod method)
+        public static IEnumerable<IParameter> Parameters(this IMethod method, bool withoutBodyParameter = false)
         {
             var parameterTypeBlackList = new[] { "CancellationToken" };
             var parameterAttributeBlackList = new[] { "FromServices" };
@@ -20,6 +19,15 @@ namespace NTypewriter.CodeModel.Functions
                 .Where(x => !parameterTypeBlackList.Contains(x.Type.Name))                
                 .Where(x => x.Attributes.All(y => !parameterAttributeBlackList.Contains(y.Name)))
                 .ToList();           
+
+            if (withoutBodyParameter)
+            {
+                var bodyParameter = method.BodyParameter();
+                if (bodyParameter != null)
+                {
+                    return dataParameters.Where(p => p.Name != bodyParameter.Name).ToList();
+                }
+            }
 
             return dataParameters.ToList();
         }

--- a/Tests.Assets.WebApi/Controllers/WeatherForecastController.cs
+++ b/Tests.Assets.WebApi/Controllers/WeatherForecastController.cs
@@ -37,6 +37,19 @@ namespace Tests.Assets.WebApi.Controllers
             .ToArray();
         }
 
+        [HttpGet("hkk/{url}")]
+        public IEnumerable<WeatherForecast> GetDataNoBody([FromServices] ILogger<WeatherForecastController> logger, int url)
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+
         [HttpPut]
         [AcceptVerbs("put", "get")]
         [Route("~/sd", Name ="some_name")]


### PR DESCRIPTION
fixes #22 

the withoutBodyParameter flag to Parameters allows the user to return the list of parameters for the method excluding the parameter that will be sent in the body of the request.

Unit tests were added, including a unit test for without this flag since that did not already exist. I also added a new method on the controller that has no body parameter. This meant I had to update the other unit tests to accomodate this new method.

I updated the docs by running the DocumentGenerator project. 