### PR TITLE
Added unit tests for ReturnType for .Net Core

### DIFF
--- a/NTypewriter.CodeModel.Functions.Tests/Action/ActionFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Action/ActionFunctionsTests.cs
@@ -40,6 +40,7 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
 
             var expected = RemoveWhitespace(
                            @"[GetData:get]
+                             [GetDataNoBody: get]
                              [SomeAsync:put]
                              [SomeAsync2:delete]
                              [ActionWithEnumParam:post]");
@@ -64,12 +65,12 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
 
             var expected = RemoveWhitespace(
                               @"[GetData:intbody]
+                                [GetDataNoBody:]
                                 [SomeAsync:InputDTObody]
                                 [SomeAsync2:InputDTObody]
                                 [ActionWithEnumParam:]");
             Assert.AreEqual(expected, actual);
         }
-
 
         [TestMethod]
         public async Task Url()
@@ -88,6 +89,7 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
 
             var expected = RemoveWhitespace(
                            @"[GetData:WeatherForecast/hkk]
+                             [GetDataNoBody:WeatherForecast/hkk/${url}]
                              [SomeAsync:sd?page=${pagg.page}&limit=${pagg.limit}]
                              [SomeAsync2:WeatherForecast/akacja/${par1}/${par2}/${par3}?par4=${par4}&par5=${par5}]
                              [ActionWithEnumParam:WeatherForecast?numbers=${numbers}&optional=${optional}&date=${date}]");
@@ -95,6 +97,52 @@ namespace NTypewriter.CodeModel.Functions.Tests.Method
             Assert.AreEqual(expected, actual);
         }
 
+        [TestMethod]
+        public async Task ReturnType()
+        {
+            var template = @"{{- capture result
+                                 for class in data.Classes | Types.ThatInheritFrom ""ControllerBase"" 
+                                     for method in class.Methods }}                       
+                                      [{{- method.Name }} : {{- method | Action.ReturnType }}]
+                                   {{- end
+                                 end 
+                                 end 
+                                 Save result ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, settings);
+            var actual = RemoveWhitespace(result.Items.First().Content);
 
+            var expected = RemoveWhitespace(
+                            @"[GetData:IEnumerable<WeatherForecast>]
+                              [GetDataNoBody:IEnumerable<WeatherForecast>]
+                              [SomeAsync:IEnumerable<WeatherForecast>]
+                              [SomeAsync2:IEnumerable<WeatherForecast>]
+                              [ActionWithEnumParam:IActionResult]");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public async Task ReturnType_with_uwrap()
+        {
+            var template = @"{{- capture result
+                                 for class in data.Classes | Types.ThatInheritFrom ""ControllerBase"" 
+                                     for method in class.Methods }}                       
+                                      [{{- method.Name }} : {{- method | Action.ReturnType | Type.Unwrap }}]
+                                   {{- end
+                                 end 
+                                 end 
+                                 Save result ""Some name"" }}
+                            ";
+            var result = await NTypeWriter.Render(template, data, settings);
+            var actual = RemoveWhitespace(result.Items.First().Content);
+
+            var expected = RemoveWhitespace(
+                            @"[GetData:WeatherForecast]
+                              [GetDataNoBody:WeatherForecast]
+                              [SomeAsync:WeatherForecast]
+                              [SomeAsync2:WeatherForecast]
+                              [ActionWithEnumParam:IActionResult]");
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/Tests.Assets.WebApi/Controllers/WeatherForecastController.cs
+++ b/Tests.Assets.WebApi/Controllers/WeatherForecastController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -37,6 +38,19 @@ namespace Tests.Assets.WebApi.Controllers
             .ToArray();
         }
 
+        [HttpGet("hkk/{url}")]
+        public ActionResult<IEnumerable<WeatherForecast>> GetDataNoBody([FromServices] ILogger<WeatherForecastController> logger, int url)
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+
         [HttpPut]
         [AcceptVerbs("put", "get")]
         [Route("~/sd", Name ="some_name")]
@@ -46,15 +60,18 @@ namespace Tests.Assets.WebApi.Controllers
         }
 
         [HttpDelete("[action]/{par1:double}/{par2=false}/{par3?}")]
+        [ProducesResponseType(StatusCodes.Status201Created)]
         [ActionName("akacja")]
-        public async Task<IEnumerable<WeatherForecast>> SomeAsync2(int par3, InputDTO body, double par1, bool par2, int par4, int par5)
+        public async Task<ActionResult<IEnumerable<WeatherForecast>>> SomeAsync2(int par3, InputDTO body, double par1, bool par2, int par4, int par5)
         {
-            return await Task.FromResult(GetData(null, 666));
+            await Task.FromResult(5);
+            return Ok(GetData(null, 666));
         }
 
-        public void ActionWithEnumParam(Numbers numbers, int? optional, DateTime date)
+        //[ProducesResponseType(typeof(WeatherForecast), StatusCodes.Status200OK)]
+        public IActionResult ActionWithEnumParam(Numbers numbers, int? optional, DateTime date)
         {
-
+            return Ok(GetData(null, 666).FirstOrDefault());
         }
     }
 


### PR DESCRIPTION
Added the different common ways of specifying the return types in .Net Core api controllers:

- just return the type
- return the type wrapped in an ActionResult
- just return the type - async
- return the type wrapped in an ActionResult - async

There is one more way that is possible, but probably not likely. The ReturnType code handles it, but we can't seem to unit test it. This is shown in the ActionWithEnumParam action in the controller. If you uncomment the ProducesResponseType attribute, the return type should be type: WeatherForecast. However, the code in the unit tests does not pick up the attribute argument. I don't know why. It should and it does in a real environment.

For now the unit test is testing that IActionResult is returned, but that shouldn't really be the case.