### PR TITLE
Add support for C# dictionary keyed on an Enum

### DIFF
--- a/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Complex/inputCode.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/ToTypeScriptType_Complex/inputCode.cs
@@ -23,6 +23,7 @@ namespace NTypewriter.CodeModel.Functions.Tests.Type.ToTypeScriptType_Complex
         int?[]? arraynull;
         List<int?>? listnull;
         Dictionary<string, short> dict;
+        Dictionary<MyEnum, string> dictWithEnumKey;
     }
 
 
@@ -30,6 +31,12 @@ namespace NTypewriter.CodeModel.Functions.Tests.Type.ToTypeScriptType_Complex
     class MyGeneric<T>
     {
 
+    }
+
+    enum MyEnum
+    {
+        EnumValue0 = 0,
+        EnumValue1 = 1
     }
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore IDE0051 // Remove unused private members

--- a/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
@@ -106,7 +106,8 @@ MyGeneric<number | null>
 MyGeneric<number | null> | null
 (number | null)[] | null
 (number | null)[] | null
-{ [key: string]: number }";
+{ [key: string]: number }
+{ [key in MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -167,7 +168,8 @@ MyGeneric<number | undefined>
 MyGeneric<number | undefined> | undefined
 (number | undefined)[] | undefined
 (number | undefined)[] | undefined
-{ [key: string]: number }";
+{ [key: string]: number }
+{ [key in MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -228,7 +230,8 @@ number[]
 MyGeneric<number>
 number[]
 number[]
-{ [key: string]: number }";
+{ [key: string]: number }
+{ [key in MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 

--- a/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
+++ b/NTypewriter.CodeModel.Functions.Tests/Type/TypeFunctionsTests.cs
@@ -107,7 +107,7 @@ MyGeneric<number | null> | null
 (number | null)[] | null
 (number | null)[] | null
 { [key: string]: number }
-{ [key in MyEnum]?: string }";
+{ [key in keyof typeof MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -169,7 +169,7 @@ MyGeneric<number | undefined> | undefined
 (number | undefined)[] | undefined
 (number | undefined)[] | undefined
 { [key: string]: number }
-{ [key in MyEnum]?: string }";
+{ [key in keyof typeof MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 
@@ -231,7 +231,7 @@ MyGeneric<number>
 number[]
 number[]
 { [key: string]: number }
-{ [key in MyEnum]?: string }";
+{ [key in keyof typeof MyEnum]?: string }";
             Assert.AreEqual(expected.Trim(), actual.Trim());
         }
 

--- a/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
+++ b/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
@@ -74,7 +74,7 @@ namespace NTypewriter.CodeModel.Functions
                         // Dictionary has Enum as a key
                         if (keyType.IsEnum)
                         {
-                            return $"{{ [key in {arguments[0]}]?: {arguments[1]} }}";
+                            return $"{{ [key in keyof typeof {arguments[0]}]?: {arguments[1]} }}";
                         }
                             
                         return $"{{ [key: {arguments[0]}]: {arguments[1]} }}";

--- a/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
+++ b/NTypewriter.CodeModel.Functions/TypeFunctions.ToTypeScriptType.cs
@@ -69,6 +69,14 @@ namespace NTypewriter.CodeModel.Functions
                     if (arguments.Count() == 2)
                     {
                         // Dictionary
+                        var keyType = type.TypeArguments.First();
+                        
+                        // Dictionary has Enum as a key
+                        if (keyType.IsEnum)
+                        {
+                            return $"{{ [key in {arguments[0]}]?: {arguments[1]} }}";
+                        }
+                            
                         return $"{{ [key: {arguments[0]}]: {arguments[1]} }}";
                     }
                 }

--- a/NTypewriter.sln.DotSettings.user
+++ b/NTypewriter.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=e8798c5c_002Df173_002D481f_002D88d6_002D2ca15ef9ede7/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="TypeFunctionsTests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;MSTest::49CCB4DB-6767-4660-8474-47ED44FD93A8::net5.0::NTypewriter.CodeModel.Functions.Tests.Type.TypeFunctionsTests&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/NTypewriter.sln.DotSettings.user
+++ b/NTypewriter.sln.DotSettings.user
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=e8798c5c_002Df173_002D481f_002D88d6_002D2ca15ef9ede7/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="TypeFunctionsTests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;MSTest::49CCB4DB-6767-4660-8474-47ED44FD93A8::net5.0::NTypewriter.CodeModel.Functions.Tests.Type.TypeFunctionsTests&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Utilizing Typescript 2.9 feature of mapped type as the generation implementation for Enum keyed dictionaries in C#.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html

Let me know if this has too many assumptions of the intended output for this.