### PR TITLE
Add rendered C# templates to compilation source when using NTypewriter.SourceGenerator

### DIFF
--- a/NTypewriter.SourceGenerator/Adapters/GeneratedFileReaderWriter.cs
+++ b/NTypewriter.SourceGenerator/Adapters/GeneratedFileReaderWriter.cs
@@ -9,25 +9,27 @@ namespace NTypewriter.SourceGenerator.Adapters
     internal class GeneratedFileReaderWriter : IGeneratedFileReaderWriter
     {
         private readonly GeneratorExecutionContext generatorExecutionContext;
+        private readonly string projectDir;
 
-        public GeneratedFileReaderWriter(GeneratorExecutionContext generatorExecutionContext)
+        public GeneratedFileReaderWriter(GeneratorExecutionContext generatorExecutionContext, string projectDir)
         {
             this.generatorExecutionContext = generatorExecutionContext;
+            this.projectDir = projectDir;
         }
 
         public bool Exists(string path)
         {
-            return !IsCSharpFile(path) && File.Exists(path);
+            return !ShouldAddToCompilation(path) && File.Exists(path);
         }
 
         public Task<string> Read(string path)
         {
-            return Task.FromResult(IsCSharpFile(path) ? string.Empty : File.ReadAllText(path));
+            return Task.FromResult(ShouldAddToCompilation(path) ? string.Empty : File.ReadAllText(path));
         }
 
         public Task Write(string path, string text)
         {
-            if (IsCSharpFile(path))
+            if (ShouldAddToCompilation(path))
                 WriteCompilationSource(path, text);
             else
                 WriteFile(path, text);
@@ -36,6 +38,8 @@ namespace NTypewriter.SourceGenerator.Adapters
         }
 
         private static bool IsCSharpFile(string path) => Path.GetExtension(path).Equals(".cs", StringComparison.OrdinalIgnoreCase);
+        private bool IsSubPathOfProject(string path) => path.StartsWith(projectDir, StringComparison.OrdinalIgnoreCase);
+        private bool ShouldAddToCompilation(string path) => IsCSharpFile(path) && IsSubPathOfProject(path);
 
         private void WriteCompilationSource(string path, string source) => generatorExecutionContext.AddSource(GenerateHintNameFromPath(path), source);
 

--- a/NTypewriter.SourceGenerator/Adapters/GeneratedFileReaderWriter.cs
+++ b/NTypewriter.SourceGenerator/Adapters/GeneratedFileReaderWriter.cs
@@ -1,22 +1,45 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using NTypewriter.Runtime;
 
 namespace NTypewriter.SourceGenerator.Adapters
 {
     internal class GeneratedFileReaderWriter : IGeneratedFileReaderWriter
     {
+        private readonly GeneratorExecutionContext generatorExecutionContext;
+
+        public GeneratedFileReaderWriter(GeneratorExecutionContext generatorExecutionContext)
+        {
+            this.generatorExecutionContext = generatorExecutionContext;
+        }
+
         public bool Exists(string path)
         {
-            return File.Exists(path);
+            return !IsCSharpFile(path) && File.Exists(path);
         }
 
         public Task<string> Read(string path)
         {
-            return Task.FromResult(File.ReadAllText(path));
+            return Task.FromResult(IsCSharpFile(path) ? string.Empty : File.ReadAllText(path));
         }
 
         public Task Write(string path, string text)
+        {
+            if (IsCSharpFile(path))
+                WriteCompilationSource(path, text);
+            else
+                WriteFile(path, text);
+            
+            return Task.CompletedTask;
+        }
+
+        private static bool IsCSharpFile(string path) => Path.GetExtension(path).Equals(".cs", StringComparison.OrdinalIgnoreCase);
+
+        private void WriteCompilationSource(string path, string source) => generatorExecutionContext.AddSource(GenerateHintNameFromPath(path), source);
+
+        private void WriteFile(string path, string text)
         {
             var dir = Path.GetDirectoryName(path);
             if (Directory.Exists(dir) == false)
@@ -24,7 +47,8 @@ namespace NTypewriter.SourceGenerator.Adapters
                 Directory.CreateDirectory(dir);
             }
             File.WriteAllText(path, text);
-            return Task.CompletedTask;
         }
+
+        private static string GenerateHintNameFromPath(string path) => Path.GetFileName(path);
     }
 }

--- a/NTypewriter.SourceGenerator/SourceGenerator.cs
+++ b/NTypewriter.SourceGenerator/SourceGenerator.cs
@@ -97,7 +97,7 @@ namespace NTypewriter.SourceGenerator
                 var userCodeProvider = new UserCodeProvider(userCodePaths);
                 var userInterfaceOutputWriter = new UserInterfaceOutputWriter();
 
-                var cmd = new RenderTemplatesCommand(null, userCodeProvider, new GeneratedFileReaderWriter(), userInterfaceOutputWriter, null, null, null, null);
+                var cmd = new RenderTemplatesCommand(null, userCodeProvider, new GeneratedFileReaderWriter(context), userInterfaceOutputWriter, null, null, null, null);
                 cmd.Execute(context.Compilation, templates).GetAwaiter().GetResult();
 
                 var log = userInterfaceOutputWriter.GetOutput();

--- a/NTypewriter.SourceGenerator/SourceGenerator.cs
+++ b/NTypewriter.SourceGenerator/SourceGenerator.cs
@@ -97,7 +97,8 @@ namespace NTypewriter.SourceGenerator
                 var userCodeProvider = new UserCodeProvider(userCodePaths);
                 var userInterfaceOutputWriter = new UserInterfaceOutputWriter();
 
-                var cmd = new RenderTemplatesCommand(null, userCodeProvider, new GeneratedFileReaderWriter(context), userInterfaceOutputWriter, null, null, null, null);
+                context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.ProjectDir", out var projectDir);
+                var cmd = new RenderTemplatesCommand(null, userCodeProvider, new GeneratedFileReaderWriter(context, projectDir), userInterfaceOutputWriter, null, null, null, null);
                 cmd.Execute(context.Compilation, templates).GetAwaiter().GetResult();
 
                 var log = userInterfaceOutputWriter.GetOutput();


### PR DESCRIPTION
Regarding #74

This small change adds rendered templates to the compilation source (instead of file system) if the render path has a `.cs` extension and is within the project directory (that the source generator is running for). For all other templates, the rendering behavior remains the same. This still allows a project to generate `.cs` files to the file system if they are not within the project.

A limitation is that filenames must be unique for rendered `.cs` templates because the source generator needs a unique name. This is unlikely to be an issue for most people.

Usage:
`{{ Save output "PartialClass.g.cs" }}` - adds the rendered template to compilation source

`{{ Save output "../Path/Outside/Project/SomethingElse.g.cs" }}` - renders template to file system (existing behavior) because resulting path is not within the project where source generator is running
