### PR TITLE
Restrict custom functions to be defined only in public static classes.

### DIFF
--- a/Documentation/CustomFunctions.md
+++ b/Documentation/CustomFunctions.md
@@ -11,6 +11,7 @@ https://www.nuget.org/packages/NTypewriter.CodeModel/
 You can extend your template with custom functions. Custom functions are defined in separate **.nt.cs** file that should be located in the same project as *.nt template file. It does not have to be csharp project though, since this file will be compiled outside of the project. This imposes  some constraints on the file:  
 
 - no external dependencies are allowed 
+- custom functions need to be defined as methods in a public static non-generic class.
 - the file will be compiled with **.net Standard 2.0** regardless of the project settings in which it is placed
 
 Sample file (*.nt.cs) with custom function and all necessary boilerplate code:
@@ -22,7 +23,7 @@ using NTypewriter.CodeModel;
 
 namespace ConsoleApp
 {    
-    class NameIsNotImportant 
+    public static class NameIsNotImportant 
     { 
         public static string MyCustomFunction(IClass @class)
         {

--- a/NTypewriter.Runtime.Tests/Configuration/GlobalConfigurationLoaderTests.cs
+++ b/NTypewriter.Runtime.Tests/Configuration/GlobalConfigurationLoaderTests.cs
@@ -22,10 +22,10 @@ namespace NTypewriter.Runtime.Tests
             var output = new IOutputMock();          
 
             var userCode = UserCodeLoader.LoadUserCodeFromGivenProject(project.FilePath, new IFileSearcherMock(), output);
-            var config = userCode.GlobalConfig;
-
-            Assert.AreEqual(false, config.AddGeneratedFilesToVSProject);
-            config.ProjectsToBeSearched.ShouldBe(new[] { "Tests.Assets.WebApi2022" });
+            
+            userCode.GlobalConfig.AddGeneratedFilesToVSProject.ShouldBeFalse();
+            userCode.GlobalConfig.ProjectsToBeSearched.ShouldBe(new[] { "Tests.Assets.WebApi2022" });
+            userCode.TypesThatMayContainCustomFunctions.Select(x => x.FullName).ShouldBe(new[] { "Tests.Assets.WebApi2022.CustomFunctions" }, ignoreOrder: true);
         }
     }
 }

--- a/NTypewriter.Runtime/UserCode/UserCodeLoader.cs
+++ b/NTypewriter.Runtime/UserCode/UserCodeLoader.cs
@@ -82,7 +82,10 @@ namespace NTypewriter.Runtime.UserCode
                         }
                     }
 
-                    result.TypesThatMayContainCustomFunctions = configAssembly.GetTypes().Where(x => x.IsClass).Where(x => x.CustomAttributes.All(y => y.AttributeType.Name != "CompilerGeneratedAttribute")).ToList();
+                    result.TypesThatMayContainCustomFunctions = configAssembly.GetTypes()
+                        .Where(x => !x.ContainsGenericParameters) // Class with generic parameters won't be able to be compiled as custom functions.
+                        .Where(x => x.IsPublic && x.IsClass && x.IsAbstract && x.IsSealed) // public static class only (static == abstract+sealed)
+                        .Where(x => x.CustomAttributes.All(y => y.AttributeType.Name != "CompilerGeneratedAttribute")).ToList();
 
                     output.Info("User code loaded successfully");
                     cache[projectFilePath] = new CacheItem(userCodeFilePaths, result);

--- a/Tests.Assets.WebApi2022/Configuration.nt.cs
+++ b/Tests.Assets.WebApi2022/Configuration.nt.cs
@@ -16,4 +16,12 @@ namespace Tests.Assets.WebApi2022
             ProjectsToBeSearched = new[] { "Tests.Assets.WebApi2022" };           
         }
     }
+
+    public static class CustomFunctions { }
+
+    #region Non valid custom function type (only non generic public static class)
+    public class PublicNonStaticClass { }
+    static class NonPublicStaticClass { }
+    public static class SomeGenericPublicStaticClass<T> { }
+    #endregion
 }

--- a/Tests.Assets.WebApi2022/RenderTemplatesCommand_HappyPath.txt
+++ b/Tests.Assets.WebApi2022/RenderTemplatesCommand_HappyPath.txt
@@ -1,3 +1,7 @@
-﻿Tests.Assets.WebApi2022.Controllers.WeatherForecastController
+Tests.Assets.WebApi2022.Controllers.WeatherForecastController
+Tests.Assets.WebApi2022.CustomFunctions
+Tests.Assets.WebApi2022.NonPublicStaticClass
+Tests.Assets.WebApi2022.PublicNonStaticClass
 Tests.Assets.WebApi2022.SampleConfig
+Tests.Assets.WebApi2022.SomeGenericPublicStaticClass<T>
 Tests.Assets.WebApi2022.WeatherForecast


### PR DESCRIPTION
This fixes a couple of issues/limitations of the .nt.cs files:
  - It shouldn't consider a generic class as it can't set the generic parameter: The fix is to filter out generic class.
  - It shouldn't consider generic static methods: To get around this whithout going too deep into scriban (and writing a custom filter) we only restrict the custom function to be in a public static class. All other 'classic' extension methods can be in an internal static class.

Note: the VS plugin need to be updated to apply the same restriction on code completion.