### PR TITLE
implement doc comments for enum value

### DIFF
--- a/NTypewriter.CodeModel.Roslyn/EnumValue.cs
+++ b/NTypewriter.CodeModel.Roslyn/EnumValue.cs
@@ -10,7 +10,7 @@ namespace NTypewriter.CodeModel.Roslyn
         public object Value => symbol.ConstantValue;
         public string Name => symbol.Name;
         public IEnumerable<IAttribute> Attributes => AttributeCollection.Create(symbol);
-
+        public IDocumentationCommentXml DocComment => DocumentationCommentXml.Create(symbol);
 
         private EnumValue(IFieldSymbol symbol)
         {

--- a/NTypewriter.CodeModel.Tests/EnumValue/DocComments/expectedResult.txt
+++ b/NTypewriter.CodeModel.Tests/EnumValue/DocComments/expectedResult.txt
@@ -1,0 +1,5 @@
+﻿One
+Two
+Three
+This is the number four. (4)Four
+This is the number five. (5)Five

--- a/NTypewriter.CodeModel.Tests/EnumValue/DocComments/inputCode.cs
+++ b/NTypewriter.CodeModel.Tests/EnumValue/DocComments/inputCode.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace NTypewriter.Tests.CodeModel
+{
+    enum EnumWithDocComments
+    {
+        One = 1,
+        Two = 2,
+        Three = 3,
+        /// <summary>
+        /// This is the number four. (4)
+        /// </summary>
+        Four = 4,
+        /// <summary>
+        /// This is the number five. (5) 
+        /// </summary>
+        Five = 5,
+    }
+}

--- a/NTypewriter.CodeModel.Tests/EnumValue/DocComments/inputTemplate.tsnt
+++ b/NTypewriter.CodeModel.Tests/EnumValue/DocComments/inputTemplate.tsnt
@@ -1,0 +1,11 @@
+﻿{{- capture captured
+    for enum in data.Enums | Symbols.WhereNamespaceStartsWith "NTypewriter.Tests.CodeModel" 
+       for enumValue in enum.Values }}
+{{- if enumValue.DocComment && enumValue.DocComment.Summary }}
+    {{- enumValue.DocComment.Summary }}
+{{- end }}
+{{- enumValue.Name }}
+{{     end 
+    end 
+    end 
+    Save captured "result" }}

--- a/NTypewriter.CodeModel.Tests/EnumValue/EnumRenderingTests.cs
+++ b/NTypewriter.CodeModel.Tests/EnumValue/EnumRenderingTests.cs
@@ -13,5 +13,11 @@ namespace NTypewriter.CodeModel.Tests.Enum
         {
             await RunTestForProperty();
         }
+
+        [TestMethod]
+        public async Task DocComments()
+        {
+            await RunTestForProperty();
+        }
     }
 }

--- a/NTypewriter.CodeModel.Tests/NTypewriter.CodeModel.Tests.csproj
+++ b/NTypewriter.CodeModel.Tests/NTypewriter.CodeModel.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Remove="DocumentationCommentXml\Returns\inputCode.cs" />
     <Compile Remove="DocumentationCommentXml\Summary\inputCode.cs" />
     <Compile Remove="EnumValue\Attributes\inputCode.cs" />
+    <Compile Remove="EnumValue\DocComments\inputCode.cs" />
     <Compile Remove="Enum\UnderlyingType\inputCode.cs" />
     <Compile Remove="Enum\Values\inputCode.cs" />
     <Compile Remove="Event\Type\inputCode.cs" />
@@ -117,6 +118,8 @@
     <None Remove="DocumentationCommentXml\Summary\inputTemplate.tsnt" />
     <None Remove="EnumValue\Attributes\expectedResult.txt" />
     <None Remove="EnumValue\Attributes\inputTemplate.tsnt" />
+    <None Remove="EnumValue\DocComments\expectedResult.txt" />
+    <None Remove="EnumValue\DocComments\inputTemplate.tsnt" />
     <None Remove="Enum\UnderlyingType\expectedResult.txt" />
     <None Remove="Enum\UnderlyingType\inputTemplate.tsnt" />
     <None Remove="Enum\Values\expectedResult.txt" />
@@ -283,6 +286,9 @@
     <EmbeddedResource Include="EnumValue\Attributes\expectedResult.txt" />
     <EmbeddedResource Include="EnumValue\Attributes\inputCode.cs" />
     <EmbeddedResource Include="EnumValue\Attributes\inputTemplate.tsnt" />
+    <EmbeddedResource Include="EnumValue\DocComments\expectedResult.txt" />
+    <EmbeddedResource Include="EnumValue\DocComments\inputCode.cs" />
+    <EmbeddedResource Include="EnumValue\DocComments\inputTemplate.tsnt" />
     <EmbeddedResource Include="Enum\UnderlyingType\expectedResult.txt" />
     <EmbeddedResource Include="Enum\UnderlyingType\inputCode.cs" />
     <EmbeddedResource Include="Enum\UnderlyingType\inputTemplate.tsnt" />

--- a/NTypewriter.CodeModel/IEnumValue.cs
+++ b/NTypewriter.CodeModel/IEnumValue.cs
@@ -23,5 +23,10 @@ namespace NTypewriter.CodeModel
         /// All attributes declared on the enum value.
         /// </summary>
         IEnumerable<IAttribute> Attributes { get; }
+
+        /// <summary>
+        /// The XML documentation for the comment associated with the symbol.
+        /// </summary>
+        IDocumentationCommentXml DocComment { get; }
     }
 }


### PR DESCRIPTION
Added DocComments to EnumValue. Read through this issue https://github.com/NeVeSpl/NTypewriter/issues/83 and realized that extending symbol base was not desired. But did not see a immediate reason that DocComments couldn't be added. 